### PR TITLE
fix: set proper z-index & position for resume-container

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -63,6 +63,11 @@ h4 {
   bottom: 0;
 }
 
+.resume-container {
+  position: relative;
+  z-index: 1;
+}
+
 .personal-container {
   margin: 12px;
   display: flex;


### PR DESCRIPTION
After adding top/bottom background without setting proper `z-index & position`, `resume-container` got overlayed by newly added `divs` which caused links (email, phone, companies' hyperlinks) to stop working.

Closes #12 